### PR TITLE
Change inner html into a pre.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,11 +50,11 @@
     </article>
 
     <div id='tour-wrapper'>
-      <wgsl-tour id='tour'><div id='tour-content' style='visibility: hidden'>
+      <wgsl-tour id='tour'><pre id='tour-content' style='visibility: hidden'>
         {{- if .Params.Shader -}}
         {{ os.ReadFile (partial "rel-path" (slice .Params.Shader .File.Dir)) -}}
         {{- end -}}
-      </div></wgsl-tour>
+      </pre></wgsl-tour>
     </div>
   </main>
 


### PR DESCRIPTION
This CL changes the inner tour text from a `div` to a `pre` element. This causes the minifier to maintain the whitespace when emitting the HTML pages. This fixes the indenting of the WGSL code in the text editor.