### PR TITLE
Show more helpful error when WebGPU is unsupported

### DIFF
--- a/assets/ts/wgsl-tour.ts
+++ b/assets/ts/wgsl-tour.ts
@@ -133,6 +133,9 @@ export class WGSLTour extends HTMLElement {
   async setVisualizationBuilder(val: VisualizerBuilder) {
     this.visualizationBuilder = val;
     try {
+      if (!navigator.gpu) {
+        throw new VisualizerError('WebGPU is not supported in this browser');
+      }
       await this.visualizationBuilder.configure(this.output);
     } catch (e) {
       this.onPipelineFailure({ message: e } as VisualizerError);


### PR DESCRIPTION
The examples currently just show `TypeError: Cannot read properties of undefined (reading 'requestAdapter')` on Chrome stable, which is not very helpful for people that are not familiar with WebGPU.