### PR TITLE
Hover style for header.

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -147,6 +147,10 @@ header {
   a {
     color: var(--main-colour);
     text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   ul {


### PR DESCRIPTION
This CL adds a underline on hover to the menu items in the header. Makes it a bit more obvious when when the cursor is over one of them.