### PR TITLE
Update Hugo baseURL

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -184,7 +184,7 @@ header {
 
     .nav_sections li {
       border-right: 1px solid rgba(0, 0, 0, 0.3);
-      text-align: left;
+      text-align: center;
     }
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
-baseURL = 'https://wgsl-tour.github.io'
+baseURL = 'https://google.github.io/tour-of-wgsl'
 languageCode = 'en-us'
-title = 'WGSL Tour'
+title = 'Tour of WGSL'
 disableKinds = ['sitemap', 'RSS']
 
 markup.highlight.noClasses = false

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
 */ -}}
 
 <header>
-  <h1><a href="{{ .Site.BaseURL }}">WGSL Tour</a></h1>
+  <h1><a href="{{ .Site.BaseURL }}">Tour of WGSL</a></h1>
 
   <nav aria-label='Sections' class="nav_sections">
     <ul>


### PR DESCRIPTION
This CL updates the Hugo `baseURL` to match the
`google.github.io/tour-of-wgsl` URL.

The title in Hugo and in the header are also updated to `Tour of WGSL`. The justification on the header menu is updated to `center` when the screen is larger which makes any word wrapping which can happen look a bit nicer.