### PR TITLE
Update pages to use {{< pages >}} short code

### DIFF
--- a/content/05-control-flow/_index.md
+++ b/content/05-control-flow/_index.md
@@ -6,8 +6,4 @@ shader: ./index.wgsl
 visualizer: /ts/graphics_visualizer.ts
 ---
 
-* [If](/control-flow/if-statements)
-* [Switch](/control-flow/switch-statements)
-* [For](/control-flow/for-statements)
-* [While](/control-flow/while-statements)
-* [Loop](/control-flow/loop-statements)
+{{< pages >}}

--- a/content/06-binding-points/_index.md
+++ b/content/06-binding-points/_index.md
@@ -3,8 +3,4 @@ title: "Binding Points"
 url: binding-points
 ---
 
-* [Attributes](/binding-points/attributes)
-* [Uniform Buffers](/binding-points/uniform-buffers)
-* [Storage Buffers](/binding-points/storage-buffers)
-* [Textures](/binding-points/textures)
-
+{{< pages >}}

--- a/content/07-uniformity-analysis/_index.md
+++ b/content/07-uniformity-analysis/_index.md
@@ -3,5 +3,4 @@ title: "Uniformity Analysis"
 url: uniformity-analysis
 ---
 
-* [Invocations](/uniformity-analysis/invocations)
-* [Fragment Derivative Builtins](/uniformity-analysis/fragment-derivative-builtins)
+{{< pages >}}


### PR DESCRIPTION
A few of the index pages were still rendering sections as a `ul`. The URLs were not updated correctly when moving to the final hosting location so the links did not work.

This CL updates those index pages to use the short code generator instead of a hard coded list.

Fixes #31