### PR TITLE
Fixup internal links.

### DIFF
--- a/content/01-functions/03-entry-points.md
+++ b/content/01-functions/03-entry-points.md
@@ -6,6 +6,8 @@ shader: ./entry-points.wgsl
 
 Functions annotated with `@vertex`, `@fragment` or `@compute` are shader entry points.
 
-Entry point names are not special, but must match the [`entryPoint`](https://www.w3.org/TR/webgpu/#dom-gpuprogrammablestage-entrypoint) name specified at pipeline creation time.
+Entry point names are not special, but must match the
+[`entryPoint`](https://www.w3.org/TR/webgpu/#dom-gpuprogrammablestage-entrypoint)
+name specified at pipeline creation time.
 
 A WGSL module can contain multiple shader entry points.

--- a/content/02-types/01-basic-scalars.md
+++ b/content/02-types/01-basic-scalars.md
@@ -10,4 +10,4 @@ The fundamental WGSL types are:
 * `f32` - an IEEE-754 binary32, floating point.
 * `bool` - a `true` or `false` value, with no specified storage representation.
 
-These types are known as concrete scalar types, and can be used in [all evaluation stages](/expressions/).
+These types are known as concrete scalar types, and can be used in [all evaluation stages]({{< ref "/03-expressions" >}}).

--- a/content/02-types/02-abstract-numerics.md
+++ b/content/02-types/02-abstract-numerics.md
@@ -18,14 +18,14 @@ Abstract-numerics have some special properties:
 * **Abstract-numeric types can't be spelled in WGSL source code**
 
   You cannot explicitly *name* an abstract-numeric type, but they exist as the type
-  of unsuffixed [numeric literals](/expressions/evaluation-stage/constant/numeric-literals),
+  of unsuffixed [numeric literals]({{< ref "/03-expressions/01-evaluation-stage/01-constant/01-numeric-literals" >}}),
   and some constant-expressions.
 
 * **Only constant-expressions can be of abstract-numeric type**
 
   Abstract-numeric values must first be converted to a concrete (non-abstract) type
-  for use as an [override-expression](/expressions/evaluation-stage/override)
-  or as a [runtime-expression](/expressions/evaluation-stage/runtime).
+  for use as an [override-expression]({{< ref "/03-expressions/01-evaluation-stage/02-override" >}})
+  or as a [runtime-expression]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}).
 
 * **Abstract-numeric expressions must be finite**
 

--- a/content/03-expressions/01-evaluation-stage/01-constant/02-builtins.md
+++ b/content/03-expressions/01-evaluation-stage/01-constant/02-builtins.md
@@ -6,7 +6,9 @@ visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [{"expr": "angle_rad", "type": "f32"}]}'
 ---
 
-All the [WGSL built-in functions](https://www.w3.org/TR/WGSL/#builtin-functions) annotated with `@const` can be evaluated at [shader creation time](https://www.w3.org/TR/webgpu/#dom-gpudevice-createshadermodule).
+All the [WGSL built-in functions](https://www.w3.org/TR/WGSL/#builtin-functions)
+annotated with `@const` can be evaluated at
+[shader creation time](https://www.w3.org/TR/webgpu/#dom-gpudevice-createshadermodule).
 
 When a call to such a function has only constant-expression arguments, then the call
 itself is a constant-expression.

--- a/content/03-expressions/01-evaluation-stage/01-constant/_index.md
+++ b/content/03-expressions/01-evaluation-stage/01-constant/_index.md
@@ -3,6 +3,7 @@ title: "Constant expressions"
 url: expressions/evaluation-stage/constant
 ---
 
-Constant-expressions are value expressions computed at [shader module creation](https://www.w3.org/TR/webgpu/#dom-gpudevice-createshadermodule) time.
+Constant-expressions are value expressions computed at
+[shader module creation](https://www.w3.org/TR/webgpu/#dom-gpudevice-createshadermodule) time.
 
 Constant-expressions can only be formed from other constant-expressions.

--- a/content/03-expressions/01-evaluation-stage/02-override/_index.md
+++ b/content/03-expressions/01-evaluation-stage/02-override/_index.md
@@ -3,7 +3,8 @@ title: "Override expressions"
 url: expressions/evaluation-stage/override
 ---
 
-Override-expressions are value expressions that are evaluated at [pipeline creation](https://www.w3.org/TR/webgpu/#pipelines) time, or earlier.
+Override-expressions are value expressions that are evaluated at
+[pipeline creation](https://www.w3.org/TR/webgpu/#pipelines) time, or earlier.
 
 >Formally, every constant-expression is an override-expression.
 >

--- a/content/03-expressions/01-evaluation-stage/03-runtime/_index.md
+++ b/content/03-expressions/01-evaluation-stage/03-runtime/_index.md
@@ -3,6 +3,7 @@ title: "Runtime expressions"
 url: expressions/evaluation-stage/runtime
 ---
 
-Runtime-expressions are value expressions that typically evaluate during execution of the shader, although they might be fully or partially evaluated earlier, if possible.
+Runtime-expressions are value expressions that typically evaluate during execution of
+the shader, although they might be fully or partially evaluated earlier, if possible.
 
 All identifiers that resolve to `var` and `let` variables are runtime-expressions.

--- a/content/03-expressions/01-evaluation-stage/_index.md
+++ b/content/03-expressions/01-evaluation-stage/_index.md
@@ -3,7 +3,7 @@ title: "Evaluation stage"
 url: expressions/evaluation-stage
 ---
 
-Value expressions are classified according to the earliest phase of execution 
+Value expressions are classified according to the earliest phase of execution
 in which they can be evaluated:
 
 {{< sections >}}

--- a/content/03-expressions/02-operators/_index.md
+++ b/content/03-expressions/02-operators/_index.md
@@ -3,14 +3,14 @@ title: "Operators"
 url: expressions/operators
 ---
 
-All the numeric types support a basic set of arithmatic operators:
+All the numeric types support a basic set of arithmetic operators:
 
 * addition: `+`
 * subtraction: `-`
 * multiplication: `*`
 * division: `/`
 
-`bool` support short-circuiting and non-short-ciruiting operators:
+`bool` support short-circuiting and non-short-circuiting operators:
 
 * bitwise-and (LHS and RHS are both always evaluated): `&`
 * logical-and (RHS is only evaluated if the LHS is true): `&&`

--- a/content/04-variables/01-var-function.md
+++ b/content/04-variables/01-var-function.md
@@ -10,7 +10,8 @@ visualizerOptions: '{"fields": [{"expr": "f()", "type": "i32"}]}'
 
 A `var<function>` can only be declared within a function.
 
-A `var<function>` declaration must have an explicit type, an initializer, or both type and initializer:
+A `var<function>` declaration must have an explicit type, an initializer,
+or both type and initializer:
 
 ```rust
 var<function> var_with_explicit_type : i32;
@@ -18,11 +19,15 @@ var<function> var_with_type_inferred_from_initializer = 42;
 var<function> var_with_explicit_type_and_initializer : i32 = 42;
 ```
 
-A `var<function>` with no initializer will be automatically initialized with the zero value for the variable's type.
+A `var<function>` with no initializer will be automatically initialized with
+the zero value for the variable's type.
 
-There are no restrictions for the [evaluation stage](/expressions/evaluation-stage) of the initializer of a `var<function>`.
+There are no restrictions for the
+[evaluation stage]({{< ref "/03-expressions/01-evaluation-stage" >}})
+of the initializer of a `var<function>`.
 
-A `var` declared within a function has the default address-space of `function`, and so most developers will simply omit the `<function>` and just type `var`:
+A `var` declared within a function has the default address-space of `function`,
+and so most developers will simply omit the `<function>` and just type `var`:
 
 ```rust
 var this_is_more_common : i32;
@@ -30,4 +35,5 @@ var this_is_more_common : i32;
 
 Each shader invocation will have a unique instance of a `var` in function address-space.
 
-Uses of a `var<function>` will always result in a [runtime](/expressions/evaluation-stage/runtime) expression.
+Uses of a `var<function>` will always result in a
+[runtime]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}) expression.

--- a/content/04-variables/02-var-private.md
+++ b/content/04-variables/02-var-private.md
@@ -8,9 +8,12 @@ visualizerOptions: '{"fields": [{"expr": "f()", "type": "i32"}]}'
 
 `var<private>` declares a mutable variable in the `private` address-space.
 
-`var<private>` is almost identical to `var<function>`, except that `var<private>` can only be declared at module-scope (global) and is visible to all functions in the module.
+`var<private>` is almost identical to `var<function>`, except that
+`var<private>` can only be declared at module-scope (global) and is visible
+to all functions in the module.
 
-Like `var<function>`, a `var<private>` declaration must have an explicit type, an initializer, or both type and initializer:
+Like `var<function>`, a `var<private>` declaration must have an explicit type,
+an initializer, or both type and initializer:
 
 ```rust
 var<private> var_with_explicit_type : i32;
@@ -18,10 +21,13 @@ var<private> var_with_type_inferred_from_initializer = 42;
 var<private> var_with_explicit_type_and_initializer : i32 = 42;
 ```
 
-A `var<private>` with no initializer will be automatically initialized with the zero value for the variable's type.
+A `var<private>` with no initializer will be automatically initialized with
+the zero value for the variable's type.
 
-The initializer for `var<private>` must be a [constant](/expressions/evaluation-stage/constant) expression.
+The initializer for `var<private>` must be a
+[constant]({{< ref "/03-expressions/01-evaluation-stage/01-constant" >}}) expression.
 
 Each shader invocation will have a unique instance of a `var` in private address-space.
 
-Uses of a `var<private>` will always result in a [runtime](/expressions/evaluation-stage/runtime) expression.
+Uses of a `var<private>` will always result in a
+[runtime]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}) expression.

--- a/content/04-variables/03-var-workgroup.md
+++ b/content/04-variables/03-var-workgroup.md
@@ -6,7 +6,10 @@ shader: ./var-workgroup.wgsl
 
 `var<workgroup>` declares a mutable variable in the `workgroup` address-space.
 
-The memory of a `var<workgroup>` variable is shared between all the invocations of the workgroup, but cross-invocation accesses must be synchronised with the use of [atomics](/types/atomics) or [`workgroupBarrier()`](https://www.w3.org/TR/WGSL/#workgroupBarrier-builtin).
+The memory of a `var<workgroup>` variable is shared between all the invocations
+of the workgroup, but cross-invocation accesses must be synchronised with the use of
+[atomics]({{< ref "/02-types/07-atomics" >}}) or
+[`workgroupBarrier()`](https://www.w3.org/TR/WGSL/#workgroupBarrier-builtin).
 
 `var<workgroup>` can only be declared at module-scope (global) and is visible to all functions in the module.
 
@@ -14,4 +17,5 @@ A `var<workgroup>` declaration must have an explicit type, and no initializer ex
 
 The value of the `var<workgroup>` variable will be automatically zero initialized before execution of the workgroup.
 
-Uses of a `var<workgroup>` will always result in a [runtime](/expressions/evaluation-stage/runtime) expression.
+Uses of a `var<workgroup>` will always result in a
+[runtime]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}) expression.

--- a/content/04-variables/07-let.md
+++ b/content/04-variables/07-let.md
@@ -3,7 +3,8 @@ title: "let"
 url: variables/let
 ---
 
-A `let` declaration gives a name to a [runtime](/expressions/evaluation-stage/runtime) immutable value.
+A `let` declaration gives a name to a
+[runtime]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}) immutable value.
 
 A `let` can only be declared within a function.
 
@@ -14,6 +15,8 @@ let let_with_explicit_type : i32 = 42;
 let let_with_type_inferred_from_initializer = 42;
 ```
 
-There are no restrictions for the [evaluation stage](/expressions/evaluation-stage) of the initializer of a `let`.
+There are no restrictions for the
+[evaluation stage]({{< ref "/03-expressions/01-evaluation-stage" >}}) of
+the initializer of a `let`.
 
 Unlike `var`, a `let` can be of a pointer type.

--- a/content/04-variables/08-const.md
+++ b/content/04-variables/08-const.md
@@ -3,7 +3,8 @@ title: "const"
 url: variables/const
 ---
 
-A `const` declaration gives a name to a [constant](/expressions/evaluation-stage/constant) immutable value.
+A `const` declaration gives a name to a
+[constant]({{< ref"/03-expressions/01-evaluation-stage/01-constant" >}}) immutable value.
 
 A `const` can be declared at module-scope or within a function.
 
@@ -14,4 +15,5 @@ const const_with_explicit_type : i32 = 42;
 const const_with_type_inferred_from_initializer = 42;
 ```
 
-The initializer of a `const` must be a [runtime](/expressions/evaluation-stage/runtime) expression.
+The initializer of a `const` must be a
+[runtime]({{< ref "/03-expressions/01-evaluation-stage/03-runtime" >}}) expression.

--- a/content/04-variables/10-shadowing.md
+++ b/content/04-variables/10-shadowing.md
@@ -3,6 +3,7 @@ title: "Shadowing"
 url: variables/shadowing
 ---
 
-Function-scope `var` and `const` variables can shadow any function, type, builtin, parameter or variable declared in a parent scope.
+Function-scope `var` and `const` variables can shadow any function, type,
+builtin, parameter or variable declared in a parent scope.
 
 It is an error to declare two variables with the same name in the same scope.


### PR DESCRIPTION
When moving to the `google.github.io/tour-of-wgsl` the URLs for the internal pages changed. This was not reflected as the URLs were not using Hugo to get the correct prefix.

This CL updates the internal URLs to use the `{{< ref >}}` shortcode in order to generate the correct URLs.