### PR TITLE
Remove `url:` front matter

### DIFF
--- a/content/binding-points/_index.md
+++ b/content/binding-points/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Binding Points"
-url: binding-points
 ---
 
 {{< pages >}}

--- a/content/binding-points/attributes.md
+++ b/content/binding-points/attributes.md
@@ -1,6 +1,5 @@
 ---
 title: "Attributes"
-url: binding-points/attributes
 ---
 
 * `@group`, `@binding`

--- a/content/binding-points/storage-buffers.md
+++ b/content/binding-points/storage-buffers.md
@@ -1,6 +1,5 @@
 ---
 title: "Storage Buffers"
-url: binding-points/storage-buffers
 ---
 
 * `var<storage> s: T`

--- a/content/binding-points/textures.md
+++ b/content/binding-points/textures.md
@@ -1,6 +1,5 @@
 ---
 title: "Textures"
-url: binding-points/textures
 ---
 
 * sampled

--- a/content/binding-points/uniform-buffers.md
+++ b/content/binding-points/uniform-buffers.md
@@ -1,6 +1,5 @@
 ---
 title: "Uniform Buffers"
-url: binding-points/uniform-buffers
 ---
 
 * Read only

--- a/content/control-flow/_index.md
+++ b/content/control-flow/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Control Flow"
-url: control-flow
 ---
 
 {{< pages >}}

--- a/content/control-flow/for-statements.md
+++ b/content/control-flow/for-statements.md
@@ -1,7 +1,5 @@
 ---
 title: "For Statements"
-url: control-flow/for-statements
-
 shader: ./for.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/control-flow/if-statements.md
+++ b/content/control-flow/if-statements.md
@@ -1,6 +1,5 @@
 ---
 title: "If Statements"
-url: control-flow/if-statements
 shader: ./if.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/control-flow/loop-statements.md
+++ b/content/control-flow/loop-statements.md
@@ -1,6 +1,5 @@
 ---
 title: "Loop Statements"
-url: control-flow/loop-statements
 ---
 
 * `continuing`

--- a/content/control-flow/switch-statements.md
+++ b/content/control-flow/switch-statements.md
@@ -1,6 +1,5 @@
 ---
 title: "Switch Statements"
-url: control-flow/switch-statement
 shader: ./switch.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/control-flow/while-statements.md
+++ b/content/control-flow/while-statements.md
@@ -1,6 +1,5 @@
 ---
 title: "While Statements"
-url: control-flow/while-statements
 ---
 
 While statements

--- a/content/expressions/_index.md
+++ b/content/expressions/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Expressions"
-url: expressions
 ---
 
 An expression in WGSL can evaluate to a value, type, function or builtin enumerator.

--- a/content/expressions/evaluation-stage/_index.md
+++ b/content/expressions/evaluation-stage/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Evaluation stage"
-url: expressions/evaluation-stage
 ---
 
 Value expressions are classified according to the earliest phase of execution

--- a/content/expressions/evaluation-stage/constant/_index.md
+++ b/content/expressions/evaluation-stage/constant/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Constant expressions"
-url: expressions/evaluation-stage/constant
 ---
 
 Constant-expressions are value expressions computed at

--- a/content/expressions/evaluation-stage/constant/bool-literals.md
+++ b/content/expressions/evaluation-stage/constant/bool-literals.md
@@ -1,6 +1,5 @@
 ---
 title: "Boolean Literals"
-url: expressions/evaluation-stage/constant/bool-literals
 ---
 
 The Boolean literals are `true` and `false`.

--- a/content/expressions/evaluation-stage/constant/builtins.md
+++ b/content/expressions/evaluation-stage/constant/builtins.md
@@ -1,6 +1,5 @@
 ---
 title: "@const built-ins"
-url: expressions/evaluation-stage/constant/builtins
 shader: ./builtins.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [{"expr": "angle_rad", "type": "f32"}]}'

--- a/content/expressions/evaluation-stage/constant/numeric-literals.md
+++ b/content/expressions/evaluation-stage/constant/numeric-literals.md
@@ -1,6 +1,5 @@
 ---
 title: "Numeric Literals"
-url: expressions/evaluation-stage/constant/numeric-literals
 ---
 
 A WGSL numeric literal is a constant-expression representing a number.

--- a/content/expressions/evaluation-stage/constant/uses.md
+++ b/content/expressions/evaluation-stage/constant/uses.md
@@ -1,6 +1,5 @@
 ---
 title: "Uses"
-url: expressions/evaluation-stage/constant/uses
 shader: ./uses.wgsl
 ---
 

--- a/content/expressions/evaluation-stage/override/_index.md
+++ b/content/expressions/evaluation-stage/override/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Override expressions"
-url: expressions/evaluation-stage/override
 ---
 
 Override-expressions are value expressions that are evaluated at

--- a/content/expressions/evaluation-stage/runtime/_index.md
+++ b/content/expressions/evaluation-stage/runtime/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Runtime expressions"
-url: expressions/evaluation-stage/runtime
 ---
 
 Runtime-expressions are value expressions that typically evaluate during execution of

--- a/content/expressions/operators/_index.md
+++ b/content/expressions/operators/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Operators"
-url: expressions/operators
 ---
 
 All the numeric types support a basic set of arithmetic operators:

--- a/content/functions/_index.md
+++ b/content/functions/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Functions"
-url: functions
 ---
 
 {{< pages >}}

--- a/content/functions/calls.md
+++ b/content/functions/calls.md
@@ -1,6 +1,5 @@
 ---
 title: "Function Calls"
-url: functions/calls
 shader: ./calls.wgsl
 ---
 

--- a/content/functions/entry-points.md
+++ b/content/functions/entry-points.md
@@ -1,6 +1,5 @@
 ---
 title: "Entry Points"
-url: functions/entry-points
 shader: ./entry-points.wgsl
 ---
 

--- a/content/functions/must-use.md
+++ b/content/functions/must-use.md
@@ -1,6 +1,5 @@
 ---
 title: "@must_use"
-url: functions/must-use
 shader: ./must-use.wgsl
 ---
 

--- a/content/functions/syntax.md
+++ b/content/functions/syntax.md
@@ -1,6 +1,5 @@
 ---
 title: "Syntax"
-url: functions/syntax
 shader: ./syntax.wgsl
 ---
 

--- a/content/types/_index.md
+++ b/content/types/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Types"
-url: types
 ---
 
 WGSL supports a wide range of types:

--- a/content/types/abstract-numerics.md
+++ b/content/types/abstract-numerics.md
@@ -1,6 +1,5 @@
 ---
 title: "Abstract-numerics"
-url: types/abstract-numerics
 shader: ./abstract-numerics.wgsl
 ---
 

--- a/content/types/arrays.md
+++ b/content/types/arrays.md
@@ -1,6 +1,5 @@
 ---
 title: "Arrays"
-url: types/arrays
 ---
 
 * `array<f32, 8>`

--- a/content/types/atomics.md
+++ b/content/types/atomics.md
@@ -1,4 +1,3 @@
 ---
 title: "Atomics"
-url: types/atomics
 ---

--- a/content/types/basic-scalars.md
+++ b/content/types/basic-scalars.md
@@ -1,6 +1,5 @@
 ---
 title: "Concrete scalars"
-url: types/concrete-scalars
 ---
 
 The fundamental WGSL types are:

--- a/content/types/matrices/_index.md
+++ b/content/types/matrices/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Matrices"
-url: types/matrices
 shader: ./index.wgsl
 ---
 

--- a/content/types/matrices/constructors.md
+++ b/content/types/matrices/constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Matrix constructors"
-url: types/matrices/constructors
 shader: ./constructors.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/types/matrices/multiplication.md
+++ b/content/types/matrices/multiplication.md
@@ -1,6 +1,5 @@
 ---
 title: "Matrix multiplication"
-url: types/matrices/multiplication
 shader: ./multiplication.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/types/pointers.md
+++ b/content/types/pointers.md
@@ -1,6 +1,5 @@
 ---
 title: "Pointers"
-url: types/pointers
 ---
 
 * `ptr<i32, function>`

--- a/content/types/structures.md
+++ b/content/types/structures.md
@@ -1,6 +1,5 @@
 ---
 title: "Structures"
-url: types/structures
 ---
 
 ```rust

--- a/content/types/vectors/_index.md
+++ b/content/types/vectors/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Vectors"
-url: types/vectors
 shader: ./index.wgsl
 ---
 

--- a/content/types/vectors/constructors.md
+++ b/content/types/vectors/constructors.md
@@ -1,6 +1,5 @@
 ---
 title: "Vector constructors"
-url: types/vectors/constructors
 shader: ./constructors.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [

--- a/content/uniformity-analysis/_index.md
+++ b/content/uniformity-analysis/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Uniformity Analysis"
-url: uniformity-analysis
 ---
 
 {{< pages >}}

--- a/content/uniformity-analysis/fragment-derivative-builtins.md
+++ b/content/uniformity-analysis/fragment-derivative-builtins.md
@@ -1,6 +1,5 @@
 ---
 title: "Fragment Derivative Builtins"
-url: uniformity-analysis/fragment-derivative-builtins
 ---
 
 * `textureSample`, `dpdx`, etc

--- a/content/uniformity-analysis/invocations.md
+++ b/content/uniformity-analysis/invocations.md
@@ -1,6 +1,5 @@
 ---
 title: "Invocations"
-url: uniformity-analysis/invocations
 ---
 
 # Invocations

--- a/content/variables/_index.md
+++ b/content/variables/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Variables and declared values"
-url: variables
 ---
 
 A *variable* represents a value stored in memory.

--- a/content/variables/const.md
+++ b/content/variables/const.md
@@ -1,6 +1,5 @@
 ---
 title: "const"
-url: variables/const
 ---
 
 A `const` declaration gives a name to a

--- a/content/variables/let.md
+++ b/content/variables/let.md
@@ -1,6 +1,5 @@
 ---
 title: "let"
-url: variables/let
 ---
 
 A `let` declaration gives a name to a

--- a/content/variables/override.md
+++ b/content/variables/override.md
@@ -1,4 +1,3 @@
 ---
 title: "override"
-url: variables/override
 ---

--- a/content/variables/shadowing.md
+++ b/content/variables/shadowing.md
@@ -1,6 +1,5 @@
 ---
 title: "Shadowing"
-url: variables/shadowing
 ---
 
 Function-scope `var` and `const` variables can shadow any function, type,

--- a/content/variables/var-function.md
+++ b/content/variables/var-function.md
@@ -1,6 +1,5 @@
 ---
 title: "var<function>"
-url: variables/var-function
 shader: ./var-function.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [{"expr": "f()", "type": "i32"}]}'

--- a/content/variables/var-handle.md
+++ b/content/variables/var-handle.md
@@ -1,5 +1,4 @@
 ---
 title: "var (handle)"
-url: variables/var-handle
 shader: ./var-handle.wgsl
 ---

--- a/content/variables/var-private.md
+++ b/content/variables/var-private.md
@@ -1,6 +1,5 @@
 ---
 title: "var<private>"
-url: variables/var-private
 shader: ./var-private.wgsl
 visualizer: /ts/value_visualizer.ts
 visualizerOptions: '{"fields": [{"expr": "f()", "type": "i32"}]}'

--- a/content/variables/var-storage.md
+++ b/content/variables/var-storage.md
@@ -1,5 +1,4 @@
 ---
 title: "var<storage>"
-url: variables/var-storage
 shader: ./var-storage.wgsl
 ---

--- a/content/variables/var-uniform.md
+++ b/content/variables/var-uniform.md
@@ -1,5 +1,4 @@
 ---
 title: "var<uniform>"
-url: variables/var-uniform
 shader: ./var-uniform.wgsl
 ---

--- a/content/variables/var-workgroup.md
+++ b/content/variables/var-workgroup.md
@@ -1,6 +1,5 @@
 ---
 title: "var<workgroup>"
-url: variables/var-workgroup
 shader: ./var-workgroup.wgsl
 ---
 


### PR DESCRIPTION
This was required when we had numerical prefixes. They're now redundant.