### PR TITLE
Add an origin trial token

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,6 +10,9 @@
   <meta charset='utf-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
 
+  <meta http-equiv="origin-trial"
+    content="ApaY+uLs0pKNwx5fiXtUO8/jdLQlmgbf1OKGkN1SnYTEj69n6RmvnaTIo+ZAvd/Lk1N5ouhPIMWzkd3Rafgu3QoAAABQeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZS5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVSIsImV4cGlyeSI6MTY5MTcxMTk5OX0=" />
+
   {{ $sass := resources.Get "sass/style.scss" }}
   {{ $style := $sass | resources.ToCSS | resources.Fingerprint }}
   <link rel="stylesheet" href="{{ $style.Permalink }}">


### PR DESCRIPTION
Allows the Tour of WGSL to be used in non-canary Chromium based browsers