### PR TITLE
Mark stub pages.

### DIFF
--- a/content/binding-points/attributes.md
+++ b/content/binding-points/attributes.md
@@ -3,4 +3,7 @@ title: "Attributes"
 url: binding-points/attributes
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `@group`, `@binding`

--- a/content/binding-points/storage-buffers.md
+++ b/content/binding-points/storage-buffers.md
@@ -3,6 +3,9 @@ title: "Storage Buffers"
 url: binding-points/storage-buffers
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `var<storage> s: T`
 * `var<storage, read> s: T`
 * `var<storage, read_write> s: T`

--- a/content/binding-points/textures.md
+++ b/content/binding-points/textures.md
@@ -3,6 +3,9 @@ title: "Textures"
 url: binding-points/textures
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * sampled
 * storage
 

--- a/content/binding-points/uniform-buffers.md
+++ b/content/binding-points/uniform-buffers.md
@@ -3,6 +3,9 @@ title: "Uniform Buffers"
 url: binding-points/uniform-buffers
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * Read only
 * Layout constraints
 

--- a/content/control-flow/loop-statements.md
+++ b/content/control-flow/loop-statements.md
@@ -3,4 +3,7 @@ title: "Loop Statements"
 url: control-flow/loop-statements
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `continuing`

--- a/content/control-flow/while-statements.md
+++ b/content/control-flow/while-statements.md
@@ -3,4 +3,6 @@ title: "While Statements"
 url: control-flow/while-statements
 ---
 
-While statements
+## STUB
+This page has yet to be written.
+

--- a/content/types/arrays.md
+++ b/content/types/arrays.md
@@ -3,6 +3,9 @@ title: "Arrays"
 url: types/arrays
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `array<f32, 8>`
 * `array<f32>`
 

--- a/content/types/atomics.md
+++ b/content/types/atomics.md
@@ -2,3 +2,7 @@
 title: "Atomics"
 url: types/atomics
 ---
+
+## STUB
+This page has yet to be written.
+

--- a/content/types/pointers.md
+++ b/content/types/pointers.md
@@ -3,5 +3,8 @@ title: "Pointers"
 url: types/pointers
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `ptr<i32, function>`
 * WGSL V1 constraints -- function parameters

--- a/content/types/structures.md
+++ b/content/types/structures.md
@@ -3,6 +3,9 @@ title: "Structures"
 url: types/structures
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 ```rust
 struct S {
   A: i32,

--- a/content/uniformity-analysis/fragment-derivative-builtins.md
+++ b/content/uniformity-analysis/fragment-derivative-builtins.md
@@ -3,5 +3,8 @@ title: "Fragment Derivative Builtins"
 url: uniformity-analysis/fragment-derivative-builtins
 ---
 
+## STUB
+This page has yet to be written. The below is a stub of potential content.
+
 * `textureSample`, `dpdx`, etc
 

--- a/content/uniformity-analysis/invocations.md
+++ b/content/uniformity-analysis/invocations.md
@@ -3,5 +3,6 @@ title: "Invocations"
 url: uniformity-analysis/invocations
 ---
 
-# Invocations
+## STUB
+This page has yet to be written.
 

--- a/content/variables/override.md
+++ b/content/variables/override.md
@@ -2,3 +2,6 @@
 title: "override"
 url: variables/override
 ---
+## STUB
+
+This page has yet to be written.

--- a/content/variables/var-handle.md
+++ b/content/variables/var-handle.md
@@ -3,3 +3,7 @@ title: "var (handle)"
 url: variables/var-handle
 shader: ./var-handle.wgsl
 ---
+
+## STUB
+This page has yet to be written.
+

--- a/content/variables/var-storage.md
+++ b/content/variables/var-storage.md
@@ -3,3 +3,7 @@ title: "var<storage>"
 url: variables/var-storage
 shader: ./var-storage.wgsl
 ---
+
+## STUB
+This page has yet to be written.
+

--- a/content/variables/var-uniform.md
+++ b/content/variables/var-uniform.md
@@ -3,3 +3,7 @@ title: "var<uniform>"
 url: variables/var-uniform
 shader: ./var-uniform.wgsl
 ---
+
+## STUB
+This page has yet to be written.
+


### PR DESCRIPTION
This CL adds a flag to pages which are a stub and need to be completed. This makes it more obvious for anyone seeing the tour that the page is not complete.