### PR TITLE
Fix `PageOrder.json`

### DIFF
--- a/data/PageOrder.json
+++ b/data/PageOrder.json
@@ -21,7 +21,7 @@
     "expressions/evaluation-stage",
     "expressions/evaluation-stage/constant",
     "expressions/evaluation-stage/constant/bool-literals",
-    "expressions/evaluation-stage/constant/numeric-limits",
+    "expressions/evaluation-stage/constant/numeric-literals",
     "expressions/evaluation-stage/constant/builtins",
     "expressions/evaluation-stage/constant/uses",
     "expressions/evaluation-stage/override",

--- a/layouts/partials/all-pages
+++ b/layouts/partials/all-pages
@@ -15,7 +15,11 @@ partial 'all-pages'
 
 *******************************************************************/ -}}
 {{ define "partials/page_by_name" }}
-{{ return (site).GetPage . }}
+{{ $page := (site).GetPage . }}
+{{ if not $page }}
+{{ errorf "data/PageOrder.json refers to non-existant page: %v" . }}
+{{ end }}
+{{ return $page }}
 {{ end }}
 
 {{return apply (site).Data.PageOrder "partial" "page_by_name" "."}}


### PR DESCRIPTION
It referred to a non-existant page.
Check paths are valid as part of the build.