### PR TITLE
Make footer vertical when screen is small.

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -195,8 +195,9 @@ header {
 
 .footer_links {
   display: flex;
-  flex-direction: row;
-  justify-content: right;
+  flex-direction: column;
+  justify-content: center;
+
   li {
     margin-left: 10px;
     a {
@@ -204,8 +205,20 @@ header {
       img {
         align-self: center;
         margin-right: 2px;
+        width: 16px;
+        height: 16px;
+
+        &.small-icon {
+          width: 12px;
+          height: 12px;
+        }
       }
     }
+  }
+}
+@media screen and (min-width: 1024px) {
+  .footer_links {
+    flex-direction: row;
   }
 }
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,14 +13,30 @@
     </div>
     <div>
       <ul class="footer_links">
-        <li><a href="https://github.com/google/tour-of-wgsl"><img src="{{.Site.BaseURL}}/third_party/icons/github/github-mark.svg"
-              width="12px" height="12px"> GitHub</a></li>
-        <li><a href="https://github.com/google/tour-of-wgsl/issues/new"><img src="{{.Site.BaseURL}}/third_party/icons/material/bug.svg"
-              width="16px" height="16px">File an Issue</a></li>
-        <li><a href="https://www.w3.org/TR/WGSL/"><img src="{{.Site.BaseURL}}/third_party/icons/material/info.svg" width="16px"
-              height="16px">WGSL Spec</a></li>
-        <li><a href="https://www.w3.org/TR/webgpu/"><img src="{{.Site.BaseURL}}/third_party/icons/material/info.svg" width="16px"
-              height="16px">WebGPU Spec</a></li>
+        <li>
+          <a href="https://github.com/google/tour-of-wgsl">
+            <img class='small-icon' src="{{.Site.BaseURL}}/third_party/icons/github/github-mark.svg">
+            GitHub
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/google/tour-of-wgsl/issues/new">
+            <img src="{{.Site.BaseURL}}/third_party/icons/material/bug.svg">
+            File an Issue
+          </a>
+        </li>
+        <li>
+          <a href="https://www.w3.org/TR/WGSL/">
+            <img src="{{.Site.BaseURL}}/third_party/icons/material/info.svg">
+            WGSL Spec
+          </a>
+        </li>
+        <li>
+          <a href="https://www.w3.org/TR/webgpu/">
+            <img src="{{.Site.BaseURL}}/third_party/icons/material/info.svg">
+            WebGPU Spec
+          </a>
+        </li>
       </ul>
     </div>
   </main>


### PR DESCRIPTION
This CL updates the footer to be responsive to the screen width. On smaller screens it's vertical, on wider it's horizontal.

The icon styling is moved into the stylesheet.