### PR TITLE
Rename `Variables and declared values` section

### DIFF
--- a/content/variables/_index.md
+++ b/content/variables/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Variables and declared values"
+title: "Variables"
 ---
 
 A *variable* represents a value stored in memory.


### PR DESCRIPTION
Drop the `and declared values` part of this. It's significantly longer than the other section names, and isn't really necessary.