### PR TITLE
Fix inconsistency in matrice variable naming

### DIFF
--- a/content/types/matrices/multiplication.md
+++ b/content/types/matrices/multiplication.md
@@ -8,7 +8,7 @@ visualizerOptions: '{"fields": [
     {"expr": "mul_m2x3_by_s",    "type": "mat2x3f"},
     {"expr": "mul_v3_by_m2x3",   "type": "vec2f"},
     {"expr": "mul_m2x3_by_v2",   "type": "vec3f"},
-    {"expr": "mul_m3x2_by_m2x4", "type": "mat4x3f"}
+    {"expr": "mul_m2x3_by_m4x2", "type": "mat4x3f"}
 ]}'
 ---
 

--- a/content/types/matrices/multiplication.wgsl
+++ b/content/types/matrices/multiplication.wgsl
@@ -18,4 +18,4 @@ const mul_v3_by_m2x3 : vec2f = vec3(9, 8, 7) * m2x3;
 // ╰      ╯           ╰           ╯
 const mul_m2x3_by_v2 : vec3f = m2x3 * vec2(9, 8);
 
-const mul_m3x2_by_m2x4 : mat4x3f = m2x3 * mat4x2f(7, 8, 9, 10, 11, 12, 13, 14);
+const mul_m2x3_by_m4x2 : mat4x3f = m2x3 * mat4x2f(7, 8, 9, 10, 11, 12, 13, 14);


### PR DESCRIPTION
This naming inconsistency confused me for a bit when going through the tutorial, better be changed.