### PR TITLE
diagram: pipeline creation can make a GPURenderPipeline

### DIFF
--- a/content/expressions/evaluation-stage/overview/_index.md
+++ b/content/expressions/evaluation-stage/overview/_index.md
@@ -58,7 +58,7 @@ sequenceDiagram
   A ->>C: device.createComputePipeline(...)<br/>or device.createRenderPipeline(...)<br>Provides GPUProgrammablestage.constants
   activate C
   Note right of C: Pipeline-creation time
-  C -->> A: a GPUComputePipeline
+  C -->> A: a GPUComputePipeline<br/>or GPURenderPipeline
   deactivate C
   Note over A,C: Create and bind resources,<br>Record GPU commands ...
   %%Note over A,C: Submit commands


### PR DESCRIPTION
Fix the diagram in the expression evaluation phases diagram.  Pipeline creation can make a GPURenderPipeline, not just a GPUComputePipeline