### PR TITLE
Added code example for var<workgroup> page.

### DIFF
--- a/content/variables/var-workgroup.wgsl
+++ b/content/variables/var-workgroup.wgsl
@@ -11,8 +11,8 @@ fn computeMain(
   @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
   //Each invocation will populate the shared workgroup data from the input data
-  local_data[local_id.x] = input_data[local_id.x];
-  local_data[local_id.x] = input_data[local_id.x];
+  wokgroup_data[local_id.x] = input_data[local_id.x];
+  workgroup_data[local_id.x] = input_data[local_id.x];
   
   //Wait for each invocation to finish their data population
   workgroupBarrier();

--- a/content/variables/var-workgroup.wgsl
+++ b/content/variables/var-workgroup.wgsl
@@ -22,12 +22,14 @@ fn computeMain(
   // Loop Pass 1:   [1, 5, 9, 13, 4, 5, 6, 7]
   // Loop Pass 2:   [6, 22, 9, 13, 4, 5, 6, 7]
   for (var current_size = workgroup_len / 2; current_size >= 1; current_size /= 2) {
-    if (local_id.x < current_size) {
+    var sum: u32 = 0;
+    if (local_id.x < u32(current_size)) {
       // Read current values from workgroup_data
-      var sum = workgroup_data[local_id.x * 2] + workgroup_data[local_id.x * 2 + 1];
-      // Wait until all invocations have finished reading from workgroup_data, and have calculated their respective sums
-      workgroupBarrier();
-      // Write sum to workgroup_data
+      sum = workgroup_data[local_id.x * 2] + workgroup_data[local_id.x * 2 + 1];
+   	}
+    // Wait until all invocations have finished reading from workgroup_data, and have calculated their respective sums
+    workgroupBarrier();
+    if (local_id.x < u32(current_size)) {
       workgroup_data[local_id.x] = sum;
     }
     // Wait for each invocation to finish one iteration of the loop, and to have finished writing to workgroup_data

--- a/content/variables/var-workgroup.wgsl
+++ b/content/variables/var-workgroup.wgsl
@@ -1,37 +1,42 @@
-//Create zero-initialized workgroup shared data
+// Create zero-initialized workgroup shared data
+const workgroup_len = 8;
 var<workgroup> workgroup_data: array<u32, 8>;
 
 @group(0) @binding(0) var<storage, read> input_data: array<u32>;
-@group(0) @binding(1) var<storage, read_write> output_data: array<u32, 1>;
+@group(0) @binding(1) var<storage, read_write> output_data: u32;
 
-//Our workgroup will execute 64 invocations of the shader, one
-@compute @workgroup_size(8, 1, 1)
+// Our workgroup will execute 8 invocations of the shader
+@compute @workgroup_size(workgroup_len, 1, 1)
 fn computeMain(
   @builtin(global_invocation_id) global_id: vec3<u32>,
   @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
-  //Each invocation will populate the shared workgroup data from the input data
-  wokgroup_data[local_id.x] = input_data[local_id.x];
+  // Each invocation will populate the shared workgroup data from the input data
   workgroup_data[local_id.x] = input_data[local_id.x];
   
-  //Wait for each invocation to finish their data population
+  // Wait for each invocation to populate their region of local data
   workgroupBarrier();
 
-  //Get the sum of the elements in the array
+  // Get the sum of the elements in the array
   //  Input Data:  [0, 1, 2, 3, 4, 5, 6, 7]
   // Loop Pass 1:   [1, 5, 9, 13, 4, 5, 6, 7]
   // Loop Pass 2:   [6, 22, 9, 13, 4, 5, 6, 7]
-  for (var currentSize = 4u; currentSize >= 1u; currentSize = currentSize / 2u) {
-    if (local_id.x < currentSize) {
-      workgroup_data[local_id.x] = workgroup_data[local_id.x * 2] + workgroup_data[local_id.x * 2 + 1]
+  for (var current_size = workgroup_len / 2; current_size >= 1; current_size = current_size / 2) {
+    if (local_id.x < current_size) {
+      // Read current values from workgroup_data
+      var sum = workgroup_data[local_id.x * 2] + workgroup_data[local_id.x * 2 + 1];
+      // Wait till all current values are read
+      workgroupBarrier();
+      // Write sum to workgroup_data
+      workgroup_data[local_id.x] = sum;
     }
-    //Wait for each invocation to attempt one iteration of the loop
+    // Wait for each invocation to finish one iteration of the loop
     workgroupBarrier();
   }
 
-  //Write the sum to the output
+  // Write the sum to the output
   if (local_id.x == 0) {
-    output_data[0] = workgroup_data[0];
+    output_data = workgroup_data[0];
   }
 
 }

--- a/content/variables/var-workgroup.wgsl
+++ b/content/variables/var-workgroup.wgsl
@@ -1,0 +1,37 @@
+//Create zero-initialized workgroup shared data
+var<workgroup> workgroup_data: array<u32, 8>;
+
+@group(0) @binding(0) var<storage, read> input_data: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output_data: array<u32, 1>;
+
+//Our workgroup will execute 64 invocations of the shader, one
+@compute @workgroup_size(8, 1, 1)
+fn computeMain(
+  @builtin(global_invocation_id) global_id: vec3<u32>,
+  @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+  //Each invocation will populate the shared workgroup data from the input data
+  local_data[local_id.x] = input_data[local_id.x];
+  local_data[local_id.x] = input_data[local_id.x];
+  
+  //Wait for each invocation to finish their data population
+  workgroupBarrier();
+
+  //Get the sum of the elements in the array
+  //  Input Data:  [0, 1, 2, 3, 4, 5, 6, 7]
+  // Loop Pass 1:   [1, 5, 9, 13, 4, 5, 6, 7]
+  // Loop Pass 2:   [6, 22, 9, 13, 4, 5, 6, 7]
+  for (var currentSize = 4u; currentSize >= 1u; currentSize = currentSize / 2u) {
+    if (local_id.x < currentSize) {
+      workgroup_data[local_id.x] = workgroup_data[local_id.x * 2] + workgroup_data[local_id.x * 2 + 1]
+    }
+    //Wait for each invocation to attempt one iteration of the loop
+    workgroupBarrier();
+  }
+
+  //Write the sum to the output
+  if (local_id.x == 0) {
+    output_data[0] = workgroup_data[0];
+  }
+
+}


### PR DESCRIPTION
Added an example showing how to perform parallel reduction on an array of input data by synchronizing updates to a var<workgroup> variable with workgroupBarriers. 