### PR TITLE
Update check_wgsl_feature.html DOM text reinterpreted as HTML

### DIFF
--- a/layouts/shortcodes/check_wgsl_feature.html
+++ b/layouts/shortcodes/check_wgsl_feature.html
@@ -7,10 +7,10 @@
         const p = document.getElementById('has_wgsl_{{$name}}');
         if (navigator.gpu.wgslLanguageFeatures.has('{{$name}}')) {
             p.classList.add('note_has_feature');
-            p.innerHTML = 'Your browser <b>supports</b> the WGSL language feature <code>{{$name}}</code>';
+            p.innerText = 'Your browser <b>supports</b> the WGSL language feature <code>{{$name}}</code>';
         } else {
             p.classList.add('note_missing_feature');
-            p.innerHTML = 'Your browser <b>does not support</b> the WGSL language feature <code>{{$name}}</code>';
+            p.innerText = 'Your browser <b>does not support</b> the WGSL language feature <code>{{$name}}</code>';
         }
     }
     catch (ex) { }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.