### PR TITLE
DOM text reinterpreted as HTML Update wgsl-tour.ts

### DIFF
--- a/assets/ts/wgsl-tour.ts
+++ b/assets/ts/wgsl-tour.ts
@@ -95,7 +95,7 @@ export class WGSLTour extends HTMLElement {
           return;
         }
         var msg = document.createElement('pre');
-        msg.innerHTML = docs;
+        msg.innerText = docs;
         msg.className = 'wgsl-tooltip';
         let tooltip = this.editor.addLineWidget(cursor.line, msg, {
           coverGutter: false,


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.