### PR TITLE
DOM text reinterpreted as HTML Update value_visualizer.ts

### DIFF
--- a/assets/ts/value_visualizer.ts
+++ b/assets/ts/value_visualizer.ts
@@ -353,7 +353,7 @@ fn main() {
       ? await shaderModule.getCompilationInfo()
       : await (shaderModule as any).compilationInfo();
     if (compilationInfo.messages.length !== 0) {
-      this.outputText.innerHTML = '';
+      this.outputText.innerText = '';
       throw new CompilationFailure(
         compilationInfo.messages.map((m) => ({
           line: m.lineNum,


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.