### PR TITLE
Update constructors.md: Incorrect list order

### DIFF
--- a/content/types/matrices/constructors.md
+++ b/content/types/matrices/constructors.md
@@ -18,7 +18,7 @@ Matrices have three kinds of constructors:
 
    `mat3x2f()` constructs a `mat3x2f` with zero-values for each of the elements.
 
-  </details>
+   </details>
 
 1. Column-wise constructor: {{< mat "mat(C)x(R)<f32>(column_0, column_1, ...)" >}}
 


### PR DESCRIPTION
Added two spaces in first element </details> 
It was not containing indented lines
<img width="796" alt="Screenshot 2024-08-09 at 5 41 23 PM" src="https://github.com/user-attachments/assets/68c54651-c1b1-433b-88d0-a445b62470b1">


