### PR TITLE
Update build-pr.yml

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Adding PR metadata
         run: echo "${{ env.PR }}" > public/pull-request.info
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: public/


### PR DESCRIPTION
The action actions/upload-artifact@v2 is deprecated. The workflows which uses this version doesn't work anymore. Upgrading this to v4 to ensure the workflow works again.

Sample broken workflow: https://github.com/google/tour-of-wgsl/actions/runs/11297134577